### PR TITLE
fix: prevent dropdown click trigger parent element clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "main": "./dist/unnnic.common.js",
   "files": [
     "dist/*",

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="unnnic-dropdown" @click="onClickTrigger">
+    <div class="unnnic-dropdown" @click.stop="onClickTrigger">
         <div class="unnnic-dropdown__trigger">
           <slot name="trigger" />
           <div


### PR DESCRIPTION
`.stop` will prevent the dropdown click to trigger parent elements `@click` events