### PR TITLE
fix: fixed one click to action in autocomplete option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "main": "./dist/unnnic.common.js",
   "files": [
     "dist/*",

--- a/src/components/Input/Autocomplete.vue
+++ b/src/components/Input/Autocomplete.vue
@@ -149,7 +149,10 @@ export default {
     onChoose(option) {
       this.val = option.text;
       this.$emit('choose', option.value ? option.value : option.text);
-      this.open = false;
+
+      this.$nextTick(() => {
+        this.open = false;
+      });
     },
     onClickOutside() {
       if (!this.open) return;


### PR DESCRIPTION
Fixed bug that was necessary to have two clicks to close autocomplete options, now just one click to select the option and close the options.